### PR TITLE
Abstract our request handler resolution

### DIFF
--- a/Source/Web.Maple.Server/AppDomainAssemblyRequestHandlerResolver.cs
+++ b/Source/Web.Maple.Server/AppDomainAssemblyRequestHandlerResolver.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Meadow.Logging;
+
+namespace Meadow.Foundation.Web.Maple;
+
+public class AppDomainAssemblyRequestHandlerResolver : IRequestHandlerResolver
+{
+    public AppDomainAssemblyRequestHandlerResolver(Logger? logger)
+    {
+        Logger = logger;
+    }
+
+    readonly Logger? Logger;
+    
+    public Type[] Resolve()
+    {
+        var resolved = new List<Type>();
+        
+        // Get classes that implement IRequestHandler
+        var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+
+        // loop through each assembly in the app and all the classes in it
+        foreach (var assembly in assemblies)
+        {
+            var types = assembly.GetTypes();
+            foreach (var t in types)
+            {
+                // if it inherits `IRequestHandler`, add it to the list
+                if (t.BaseType != null)
+                {
+                    if (t.BaseType.GetInterfaces().Contains(typeof(IRequestHandler)))
+                    {
+                        resolved.Add(t);
+                    }
+                }
+            }
+        }
+
+        return resolved.ToArray();
+    }
+}

--- a/Source/Web.Maple.Server/IRequestHandlerResolver.cs
+++ b/Source/Web.Maple.Server/IRequestHandlerResolver.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace Meadow.Foundation.Web.Maple;
+
+public interface IRequestHandlerResolver
+{
+    Type[] Resolve();
+}


### PR DESCRIPTION
Currently the default is to inspect all the assemblies in the current appdomain for types implementing `IRequestHandler` but it would be nice to be able to customize this resolution.  This abstracts the concept out so you can provide your own resolver and suggest the types explicitly that should be used.